### PR TITLE
Treat 0.x minor bumps as majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,7 @@
       "excludePackagePrefixes": ["@balena"],
       "commitBody": "Change-type: patch",
       "extends": ["schedule:weekends"],
+      "matchCurrentVersion": ">=1.0.0",
       "matchUpdateTypes": [
         "minor",
         "patch"
@@ -56,6 +57,7 @@
     },
     {
       "matchPackagePrefixes": ["@balena"],
+      "matchCurrentVersion": ">=1.0.0",
       "matchUpdateTypes": [
         "minor"
       ],


### PR DESCRIPTION
According to semver documentation 0.x minor bumps
can include breaking changes meaning we should
treat them the same as majors.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>