### PR TITLE
Update zero minor bump rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,12 @@
   ],
   "packageRules": [
     {
-      "groupName": "internal-patch",
+      "groupName": "internal-non-major",
       "matchPackagePrefixes": ["@balena"],
       "commitBody": "Change-type: patch",
+      "matchCurrentVersion": ">=1.0.0",
       "matchUpdateTypes": [
+        "minor",
         "patch"
       ],
       "automerge": true
@@ -56,12 +58,23 @@
       ]
     },
     {
+      "groupName": "internal-zero-minor",
       "matchPackagePrefixes": ["@balena"],
-      "matchCurrentVersion": ">=1.0.0",
+      "commitBody": "Change-type: patch",
+      "matchCurrentVersion": "<1.0.0",
       "matchUpdateTypes": [
         "minor"
-      ],
-      "automerge": true
+      ]
+    },
+    {
+      "groupName": "external-zero-minor",
+      "excludePackagePrefixes": ["@balena"],
+      "commitBody": "Change-type: patch",
+      "extends": ["schedule:weekends"],
+      "matchCurrentVersion": "<1.0.0",
+      "matchUpdateTypes": [
+        "minor"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Create groups specifically for v0 minor bumps. The previous changes added in to handle these bumps in https://github.com/product-os/renovate-config/pull/17 had the unwanted side effect of external v0 packages being bumped during weekdays.

Also consolidate two groups resulting in `internal-non-major`, now a proper mirror to `external-non-major`.