### PR TITLE
Disable submodule bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,6 @@
     "dockerfile",
     "docker-compose"
   ],
-  "git-submodules": {
-    "enabled": true
-  },
   "force": {
     "constraints": {
       "node": "< 17.0.0",


### PR DESCRIPTION
Disabling Renovate submodule updates as I've seen cases in which
it tries to delete them instead. We don't update secrets very
often anyway.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>