### PR TITLE
Update concurrent limits

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,7 +14,8 @@
     }
   },
   "pruneStaleBranches": false,
-  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 3,
+  "prConcurrentLimit": 3,
   "ignoreDeps": [
     "node"
   ],


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>

---

Updating limits to 3 to account for 2 groups and 1 more for individual bumps