### PR TITLE
Reduce concurrency from 3 to 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,8 @@
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "from {{currentVersion}} to {{newVersion}}",
   "commitBody": "Change-type: patch",
-  "branchConcurrentLimit": 3,
-  "prConcurrentLimit": 3,
+  "branchConcurrentLimit": 2,
+  "prConcurrentLimit": 2,
   "labels": [
     "renovate",
     "dependencies"


### PR DESCRIPTION
Reduce concurrency as one of our two package rule groups is not
used very often and we instead end up having two mergeable PRs
fighting with one another. This results in one of them merging and the
other having to be rebased and trying again.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>