### PR TITLE
Reduce concurrency from 2 to 1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,8 @@
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "from {{currentVersion}} to {{newVersion}}",
   "commitBody": "Change-type: patch",
-  "branchConcurrentLimit": 2,
-  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 1,
+  "prConcurrentLimit": 1,
   "labels": [
     "renovate",
     "dependencies"


### PR DESCRIPTION
A concurrency of 2 creates too many competing pull requests in most
repos. product-os/jellyfish needs at least 2, so will override in its
renovate config.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>