### PR TITLE
Enable Github Actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "enabledManagers": [
     "npm",
     "dockerfile",
-    "docker-compose"
+    "docker-compose",
+    "github-actions"
   ],
   "git-submodules": {
     "enabled": false


### PR DESCRIPTION
This action will bump pinned versions of github actions and should be low risk to enable.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>