### PR TITLE
Fix commit message for digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,8 +24,7 @@
     "{{updateType}}",
     "{{#if (and (not(isPatch)) (containsString prettyNewMajor 'v0'))}}major{{else}}{{depType}}{{/if}}"
   ],
-  "commitMessageExtra": "to {{{replace 'v' '' newVersion}}}",
-  "commitBody": "Update {{depName}} to {{{replace 'v' '' newVersion}}}\n\nUpdate {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}\n\nChange-type: {{#if (or isPatch (containsString depType 'devDependencies'))}}patch{{else}}minor{{/if}}",
+  "commitBody": "{{#if (containsString depType 'digest')}}Update {{depName}}{{else}}Update {{depName}} from {{{replace 'v' '' currentVersion}}} to {{{replace 'v' '' newVersion}}}{{/if}}\n\nChange-type: {{#if (or isPatch (containsString depType 'devDependencies') (containsString depType 'digest'))}}patch{{else}}minor{{/if}}",
   "prConcurrentLimit": 2,
   "branchConcurrentLimit": 2,
   "ignorePaths": [


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Avoid commit messages like this: https://github.com/product-os/flowzone/commit/a624cd395f3e82872b6c85390d50f22ad351313e