### PR TITLE
Self-hosted config should inherit org defaults

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>product-os/renovate-config"],
   "onboarding": false,
   "requireConfig": "optional",
   "allowPostUpgradeCommandTemplating": true,


### PR DESCRIPTION
Without onboarding we actually need to provide the org defaults directly in the self-hosted configuration.

Change-type: patch