### PR TITLE
Remove custom versioning for self-hosted runners

### DIFF
--- a/default.json
+++ b/default.json
@@ -79,11 +79,6 @@
       "matchUpdateTypes": ["pin", "pinDigest"],
       "commitBody": "Pin {{depName}}\n\nChange-type: patch",
       "automerge": true
-    },
-    {
-      "matchPackagePatterns": [".*product-os/self-hosted-runners$"],
-      "matchDatasources": ["docker"],
-      "versioning": "regex:^((?<compatibility>.*)-)?v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
As of v1.2.8 the self-hosted runner docker tags are following the expected semver-compatibility syntax.

Change-type: patch