### PR TITLE
renovate kubernetes

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,10 +28,16 @@
     "product-os/balena-versionist",
     "product-os/environment-production",
     "product-os/environment-staging",
+    "product-os/environments",
     "product-os/flowzone",
     "product-os/renovate-config",
     "product-os/self-hosted-runners",
     "product-os/versionbot",
     "product-os/balena-typescript-skeleton"
-  ]
+  ],
+  "kubernetes": {
+    "fileMatch": [
+      "kube\/.+\\.y[a]?ml$"
+    ]
+  }
 }


### PR DESCRIPTION
.. let Renovate loose on kubernetes manifests (product-os/environments/kube/*).

This is safe to merge as it only looks at the `kube` directory and only `product-os/environments` has it (existing envs. use `kubernetes/`). We can see how it behaves and tune as required.