### PR TITLE
clone private submodules

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -61,12 +61,15 @@ jobs:
                 "hostType": "github",
                 "matchHost": "api.github.com",
                 "token": "${{ steps.app_token.outputs.token }}",
+                "username": "token",
+                "password": "${{ steps.app_token.outputs.token }}",
               },
               {
                 "hostType": "github",
-                "domainName": "github.com",
                 "matchHost": "github.com",
                 "token": "${{ steps.app_token.outputs.token }}",
+                "username": "token",
+                "password": "${{ steps.app_token.outputs.token }}"
               },
               {
                 "username": "token",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -58,24 +58,8 @@ jobs:
                 "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
-                "hostType": "github",
-                "matchHost": "api.github.com",
-                "token": "${{ steps.app_token.outputs.token }}",
-                "username": "token",
-                "password": "${{ steps.app_token.outputs.token }}",
-              },
-              {
-                "hostType": "github",
                 "matchHost": "github.com",
-                "token": "${{ steps.app_token.outputs.token }}",
                 "username": "token",
                 "password": "${{ steps.app_token.outputs.token }}"
-              },
-              {
-                "username": "token",
-                "password": "${{ steps.app_token.outputs.token }}",
-                "token": "${{ steps.app_token.outputs.token }}",
-                "hostType": "git-refs",
-                "matchHost": "github.com"
               }
             ]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -65,11 +65,14 @@ jobs:
               {
                 "hostType": "github",
                 "domainName": "github.com",
+                "matchHost": "github.com",
                 "token": "${{ steps.app_token.outputs.token }}",
               },
               {
-                "hostType": "github",
-                "matchHost": "github.com",
+                "username": "token",
+                "password": "${{ steps.app_token.outputs.token }}",
                 "token": "${{ steps.app_token.outputs.token }}",
+                "hostType": "git-refs",
+                "matchHost": "github.com"
               }
             ]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -61,5 +61,15 @@ jobs:
                 "hostType": "github",
                 "matchHost": "api.github.com",
                 "token": "${{ steps.app_token.outputs.token }}",
+              },
+              {
+                "hostType": "github",
+                "domainName": "github.com",
+                "token": "${{ steps.app_token.outputs.token }}",
+              },
+              {
+                "hostType": "github",
+                "matchHost": "github.com",
+                "token": "${{ steps.app_token.outputs.token }}",
               }
             ]


### PR DESCRIPTION
regardless of hostRules, Renovate is unable to clone a private submodule:

```
2024-02-13T21:47:02.9599483Z DEBUG: Reinitializing hostRules for repo
2024-02-13T21:47:02.9599864Z DEBUG: Clearing hostRules
2024-02-13T21:47:02.9600368Z DEBUG: Adding password authentication for ghcr.io (hostType=docker) to hostRules
2024-02-13T21:47:02.9601489Z DEBUG: Adding password authentication for github.com (hostType=undefined) to hostRules
2024-02-13T21:47:02.9603065Z DEBUG: Adding token authentication for api.github.com (hostType=github) to hostRules
2024-02-13T21:47:02.9608046Z  INFO: Repository started (repository=product-os/environment-playground)
2024-02-13T21:47:02.9608941Z        "renovateVersion": "37.187.1"
2024-02-13T21:47:02.9610383Z DEBUG: Using localDir: /tmp/renovate/repos/github/product-os/environment-playground (repository=product-os/environment-playground)
2024-02-13T21:47:02.9611636Z DEBUG: PackageFiles.clear() - Package files deleted (repository=product-os/environment-playground)
2024-02-13T21:47:02.9615572Z DEBUG: initRepo("product-os/environment-playground") (repository=product-os/environment-playground)
2024-02-13T21:47:02.9622490Z DEBUG: hostRules: authentication already set for api.github.com (repository=product-os/environment-playground)
2024-02-13T21:47:03.1008072Z DEBUG: product-os/environment-playground default branch = master (repository=product-os/environment-playground)
2024-02-13T21:47:03.1009808Z DEBUG: Using app token for git init (repository=product-os/environment-playground)
2024-02-13T21:47:03.3893752Z DEBUG: Resetting npmrc (repository=product-os/environment-playground)
2024-02-13T21:47:03.3895119Z DEBUG: Resetting npmrc (repository=product-os/environment-playground)
2024-02-13T21:47:03.3896572Z DEBUG: checkOnboarding() (repository=product-os/environment-playground)
2024-02-13T21:47:03.3897847Z DEBUG: isOnboarded() (repository=product-os/environment-playground)
2024-02-13T21:47:03.3899083Z DEBUG: Repo is onboarded (repository=product-os/environment-playground)
2024-02-13T21:47:03.3901848Z DEBUG: Initializing git repository into /tmp/renovate/repos/github/product-os/environment-playground (repository=product-os/environment-playground)
2024-02-13T21:47:03.3903519Z DEBUG: Performing blobless clone (repository=product-os/environment-playground)
2024-02-13T21:47:03.9753821Z DEBUG: git clone completed (repository=product-os/environment-playground)
2024-02-13T21:47:03.9754642Z        "durationMs": 585
2024-02-13T21:47:03.9910644Z DEBUG: Cloning git submodule at base (repository=product-os/environment-playground)
2024-02-13T21:47:04.1867169Z DEBUG: Git function thrown (repository=product-os/environment-playground)
2024-02-13T21:47:04.1868085Z        "err": {
2024-02-13T21:47:04.1868505Z          "task": {
2024-02-13T21:47:04.1869220Z            "commands": ["submodule", "update", "--init", "base"],
2024-02-13T21:47:04.1870039Z            "format": "utf-8",
2024-02-13T21:47:04.1870611Z            "parser": "[function]"
2024-02-13T21:47:04.1871113Z          },
2024-02-13T21:47:04.1875755Z          "message": "Submodule 'base' (https://github.com/product-os/environments-base.git) registered for path 'base'\nCloning into '/tmp/renovate/repos/github/product-os/environment-playground/base'...\nfatal: could not read Username for 'https://github.com': No such device or address\nfatal: clone of 'https://github.com/product-os/environments-base.git' into submodule path '/tmp/renovate/repos/github/product-os/environment-playground/base' failed\nFailed to clone 'base'. Retry scheduled\nCloning into '/tmp/renovate/repos/github/product-os/environment-playground/base'...\nfatal: could not read Username for 'https://github.com': No such device or address\nfatal: clone of 'https://github.com/product-os/environments-base.git' into submodule path '/tmp/renovate/repos/github/product-os/environment-playground/base' failed\nFailed to clone 'base' a second time, aborting\n",
2024-02-13T21:47:04.1884607Z          "stack": "Error: Submodule 'base' (https://**redacted**@3.22.0/node_modules/simple-git/src/lib/plugins/error-detection.plugin.ts:42:29)\n    at PluginStore.exec (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/plugins/plugin-store.ts:29:29)\n    at /usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:127:42\n    at new Promise (<anonymous>)\n    at GitExecutorChain.handleTaskData (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:124:14)\n    at GitExecutorChain.<anonymous> (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:100:40)\n    at Generator.next (<anonymous>)\n    at fulfilled (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/dist/cjs/index.js:55:24)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)"
2024-02-13T21:47:04.1889930Z        }
2024-02-13T21:47:04.1890552Z  WARN: Unable to initialise git submodule at base (repository=product-os/environment-playground)
2024-02-13T21:47:04.1891143Z        "err": {
2024-02-13T21:47:04.1891511Z          "task": {
2024-02-13T21:47:04.1891927Z            "commands": ["submodule", "update", "--init", "base"],
2024-02-13T21:47:04.1892388Z            "format": "utf-8",
2024-02-13T21:47:04.1892694Z            "parser": "[function]"
2024-02-13T21:47:04.1892993Z          },
2024-02-13T21:47:04.1897467Z          "message": "Submodule 'base' (https://github.com/product-os/environments-base.git) registered for path 'base'\nCloning into '/tmp/renovate/repos/github/product-os/environment-playground/base'...\nfatal: could not read Username for 'https://github.com': No such device or address\nfatal: clone of 'https://github.com/product-os/environments-base.git' into submodule path '/tmp/renovate/repos/github/product-os/environment-playground/base' failed\nFailed to clone 'base'. Retry scheduled\nCloning into '/tmp/renovate/repos/github/product-os/environment-playground/base'...\nfatal: could not read Username for 'https://github.com': No such device or address\nfatal: clone of 'https://github.com/product-os/environments-base.git' into submodule path '/tmp/renovate/repos/github/product-os/environment-playground/base' failed\nFailed to clone 'base' a second time, aborting\n",
2024-02-13T21:47:04.1906055Z          "stack": "Error: Submodule 'base' (https://**redacted**@3.22.0/node_modules/simple-git/src/lib/plugins/error-detection.plugin.ts:42:29)\n    at PluginStore.exec (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/plugins/plugin-store.ts:29:29)\n    at /usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:127:42\n    at new Promise (<anonymous>)\n    at GitExecutorChain.handleTaskData (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:124:14)\n    at GitExecutorChain.<anonymous> (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:100:40)\n    at Generator.next (<anonymous>)\n    at fulfilled (/usr/local/renovate/node_modules/.pnpm/simple-git@3.22.0/node_modules/simple-git/dist/cjs/index.js:55:24)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)"
2024-02-13T21:47:04.1910611Z        }
```

.. I've made a minimal reproduction and opened an [issue](https://github.com/renovatebot/renovate/discussions/27280).