### PR TITLE
Remove kubernetes file matching from org-wide setting

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,10 +33,5 @@
     "product-os/self-hosted-runners",
     "product-os/versionbot",
     "product-os/balena-typescript-skeleton"
-  ],
-  "kubernetes": {
-    "fileMatch": [
-      "kube\/.+\\.y[a]?ml$"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
All repositories requiring kubernetes file matching
have custom renovate configs with the required file match.

Change-type: patch